### PR TITLE
Advertising Bid Adapter: Update the regex while parsing bid.impid to support the change to UUID format for bid ids

### DIFF
--- a/modules/advertisingBidAdapter.js
+++ b/modules/advertisingBidAdapter.js
@@ -236,7 +236,7 @@ export const spec = {
         seatbid.bid.forEach(bid => {
           const creative = updateMacros(bid, bid.adm);
           const nurl = updateMacros(bid, bid.nurl);
-          const [, impType, impid] = bid.impid.match(/^([vb])([\w\d]+)/);
+          const [, impType, impid] = bid.impid.match(/^([vb])(.*)$/);
           let height = bid.h;
           let width = bid.w;
           const isVideo = impType === 'v';


### PR DESCRIPTION

<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

In Prebid 10.7.0, a change was released that updated how the request bid ids are formed (See https://github.com/prebid/Prebid.js/pull/13698) 

In advertising.com's bid adapter (bidderCode: advertising), we have a regex that we use to parse the incoming `bid.impid`. We do this since we prepend request bid id by `b` or `v` in our response to indicate whether the impression is banner or video. The regex expected alphanumeric characters to follow after the `b` or `v` which was the case per the previous bid id format. However, with the UUID based format, `-` characters are introduced too which breaks the `bid.impid` parsing.

So, an incoming response `bid.impid` of `b07d74d2f-27ce-4f98-915b-211bc91f7d71` would actually be parsed to `07d74d2f` as opposed to expected `07d74d2f-27ce-4f98-915b-211bc91f7d71` after correctly stripping off `b`. This causes a mismatch between bid request and bid response id and results in our adapter completely breaking since the incoming bids are discarded. Warnings like the following are logged.

> WARNING: Bidder advertising made bid for unknown request ID: 07d74d2f. Ignoring.

I have updated the regex to accept everything after 'b' or 'v' and have confirmed that this fixes the issue.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
